### PR TITLE
feat: Add home battery specific capabilities

### DIFF
--- a/app.json
+++ b/app.json
@@ -910,17 +910,6 @@
                   }
               },
               {
-                  "id": "set_energy_home_battery",
-                  "type": "checkbox",
-                  "value": false,
-                  "label": {
-                      "en": "Home Battery"
-                  },
-                  "hint": {
-                      "en": "Define a device with class=battery having a measure_power capability as home battery. Provide positive values to indicate the battery is consuming energy (charging), provide negative values to indicate the battery is delivering energy back to the home (discharging)"
-                  }
-              },
-              {
                   "id": "set_energy_cumulative_imported_capability",
                   "type": "text",
                   "value": "",
@@ -938,6 +927,42 @@
                       "en": "Meter capability for exported energy",
                       "de": "Zähler-Capability für exportierte Energie",
                       "nl": "Meter capability voor exporteerde energie"
+                  }
+              }
+          ]
+        },
+        {
+          "type": "group",
+          "label": {
+              "en": "Home Battery"
+          },
+          "children":
+          [
+              {
+                  "id": "set_energy_home_battery",
+                  "type": "checkbox",
+                  "value": false,
+                  "label": {
+                      "en": "Home Battery"
+                  },
+                  "hint": {
+                      "en": "Define a device with class=battery having a measure_power capability as home battery. Provide positive values to indicate the battery is consuming energy (charging), provide negative values to indicate the battery is delivering energy back to the home (discharging)"
+                  }
+              },
+              {
+                  "id": "set_energy_meter_power_imported_capability",
+                  "type": "text",
+                  "value": "",
+                  "label": {
+                      "en": "Meter capability for energy charged by the battery"
+                  }
+              },
+              {
+                  "id": "set_energy_meter_power_exported_capability",
+                  "type": "text",
+                  "value": "",
+                  "label": {
+                      "en": "Meter capability for energy discharged by the battery"
                   }
               }
           ]

--- a/drivers/device/device.js
+++ b/drivers/device/device.js
@@ -47,6 +47,8 @@ class MQTTDevice extends Homey.Device {
             settings["set_energy_home_battery"] = energy["homeBattery"] != undefined ? energy["homeBattery"] : false;
             settings["set_energy_cumulative_imported_capability"] = energy["cumulativeImportedCapability"] != undefined ? energy["cumulativeImportedCapability"] : "";
             settings["set_energy_cumulative_exported_capability"] = energy["cumulativeExportedCapability"] != undefined ? energy["cumulativeExportedCapability"] : "";
+            settings["set_energy_meter_power_imported_capability"] = energy["meterPowerImportedCapability"] != undefined ? energy["meterPowerImportedCapability"] : "";
+            settings["set_energy_meter_power_exported_capability"] = energy["meterPowerExportedCapability"] != undefined ? energy["meterPowerExportedCapability"] : "";
             await this.setSettings(settings);
         }
         catch(error){
@@ -136,6 +138,18 @@ class MQTTDevice extends Homey.Device {
                 await this._setEnergyCumulativeExportedCapability(newSettings['set_energy_cumulative_exported_capability']);
             }
         }
+        if (changedKeys.indexOf('set_energy_meter_power_imported_capability') > -1){
+            if (newSettings['set_energy_meter_power_imported_capability'] != undefined){
+                this.log("onSettings(): set_energy_meter_power_imported_capability: "+newSettings['set_energy_meter_power_imported_capability']);
+                await this._setEnergyMeterPowerImportedCapability(newSettings['set_energy_meter_power_imported_capability']);
+            }
+        }
+        if (changedKeys.indexOf('set_energy_meter_power_exported_capability') > -1){
+            if (newSettings['set_energy_meter_power_exported_capability'] != undefined){
+                this.log("onSettings(): set_energy_meter_power_exported_capability: "+newSettings['set_energy_meter_power_exported_capability']);
+                await this._setEnergyMeterPowerExportedCapability(newSettings['set_energy_meter_power_exported_capability']);
+            }
+        }
 
     }
 
@@ -174,6 +188,32 @@ class MQTTDevice extends Homey.Device {
         }
         else{
             energy["cumulativeExportedCapability"] =  value;
+        }
+        await this.setEnergy( energy );
+    }
+
+    async _setEnergyMeterPowerImportedCapability(value){
+        let energy = JSON.parse(JSON.stringify(this.getEnergy())) || {};
+        if (value == ''){
+            if (energy["meterPowerImportedCapability"]){
+                delete  energy["meterPowerImportedCapability"];
+            }
+        }
+        else{
+            energy["meterPowerImportedCapability"] =  value;
+        }
+        await this.setEnergy( energy );
+    }
+
+    async _setEnergyMeterPowerExportedCapability(value){
+        let energy = JSON.parse(JSON.stringify(this.getEnergy())) || {};
+        if (value == ''){
+            if (energy["meterPowerExportedCapability"]){
+                delete energy["meterPowerExportedCapability"];
+            }
+        }
+        else{
+            energy["meterPowerExportedCapability"] =  value;
         }
         await this.setEnergy( energy );
     }


### PR DESCRIPTION
To be able to setup a home battery correctly for the energy tab, I needed two additional capabilities: `meterPowerImportedCapability` and `meterPowerExportedCapability` for respectively charged and discharged energy. See docs: https://apps.developer.homey.app/the-basics/devices/energy#home-batteries

I thought it would be nice to group it under a `Home Battery` group, but I'm fine moving it back to the existing `Energy` group.

Screenshot from my phone:

![20D12BDE-E778-4462-A349-855BFEC1056A_4_5005_c](https://github.com/user-attachments/assets/5044dcc6-f3f7-4e52-a765-2ac3f7ce63e6)
