### PR TITLE
Change parsing condition onoff capabilities to be .startsWith('onoff')

### DIFF
--- a/drivers/device/device.js
+++ b/drivers/device/device.js
@@ -547,7 +547,7 @@ class MQTTDevice extends Homey.Device {
         }
 
         const topic = config.setTopic;
-        let payload = capabilityId === 'onoff'
+        let payload = capabilityId.startsWith('onoff')
             ? (config.outputTemplate ? value : formatOnOff(value, this.onOffValues))
             : formatValue(value, CAPABILITIES[capabilityId], this.percentageScale);
 


### PR DESCRIPTION
A setting in the mqtt device permits mapping of onoff (true/false) values to other pairs of values, including on/off.  This works fine for the base "onoff" capability.  

I have a multi-gang wall socket that requires 4 onoff capabilities.  The mapping works fine for the first capability, but not for any subsequent capabilities (labelled onoff.1, onoff.2 etc).

The test is too strict looking for an exact match with 'onoff'.  Changing the condition to `.startsWith('onoff')` successfully matches all onoff capabilities..  